### PR TITLE
fix: allow checkout private submodule

### DIFF
--- a/.github/workflows/ci-check-infra.yml
+++ b/.github/workflows/ci-check-infra.yml
@@ -36,6 +36,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: recursive
+          token: ${{ secrets.RELEASE_PAT }}
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v2
@@ -55,6 +56,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: recursive
+          token: ${{ secrets.RELEASE_PAT }}
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v2
@@ -84,6 +86,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: recursive
+          token: ${{ secrets.RELEASE_PAT }}
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v2
@@ -114,6 +117,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: recursive
+          token: ${{ secrets.RELEASE_PAT }}
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v2

--- a/.github/workflows/ci-plan-infra.yml
+++ b/.github/workflows/ci-plan-infra.yml
@@ -66,6 +66,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: recursive
+          token: ${{ secrets.RELEASE_PAT }}
 
       - name: Configure AWS Credentials for Monitoring account
         uses: aws-actions/configure-aws-credentials@v4


### PR DESCRIPTION
Fixes failing checkout in https://github.com/WalletConnect/notify-server/actions/runs/7701952663/job/20989862195?pr=343

This is because `rs-relay` was added as a submodule which is a private repo. This requires a token to checkout the private repo.