### PR TITLE
fix: missing token for submodule checkout

### DIFF
--- a/.github/workflows/deploy-infra.yml
+++ b/.github/workflows/deploy-infra.yml
@@ -66,6 +66,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
+          token: ${{ secrets.RELEASE_PAT }}
 
       - name: Configure AWS Credentials for Monitoring account
         uses: aws-actions/configure-aws-credentials@v4


### PR DESCRIPTION
Resolves https://github.com/WalletConnect/notify-server/actions/runs/7788733490/job/21239193927

Follow-up to https://github.com/WalletConnect/ci_workflows/pull/1