### PR TITLE
fix: udeps no longer compiles on nightly

### DIFF
--- a/.github/workflows/ci-check-app.yml
+++ b/.github/workflows/ci-check-app.yml
@@ -22,7 +22,7 @@ on:
       rust-toolchain-udeps:
         description: 'The Rust version to use to run udeps'
         type: string
-        default: 'stable'
+        default: 'nightly-2024-02-04'
       rust-backtrace:
         description: 'The Rust backtrace settings'
         type: string

--- a/.github/workflows/ci-check-app.yml
+++ b/.github/workflows/ci-check-app.yml
@@ -20,9 +20,9 @@ on:
         type: string
         default: 'nightly'
       rust-toolchain-udeps:
-        description: 'The Rust version to use to check formatting'
+        description: 'The Rust version to use to run udeps'
         type: string
-        default: 'nightly'
+        default: 'stable'
       rust-backtrace:
         description: 'The Rust backtrace settings'
         type: string
@@ -95,7 +95,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install Rust ${{ inputs.rust-toolchain }}
+      - name: Install Rust ${{ inputs.rust-toolchain-formatting }}
         uses: WalletConnect/actions-rs/toolchain@2.0.0
         with:
           toolchain: ${{ inputs.rust-toolchain-formatting }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ on:
       rust-toolchain-udeps:
         description: 'The Rust version to use to run udeps'
         type: string
-        default: 'stable'
+        default: 'nightly-2024-02-04'
       rust-backtrace:
         description: 'The Rust backtrace settings'
         type: string

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,10 @@ on:
         description: 'The Rust version to use to check formatting'
         type: string
         default: 'nightly'
+      rust-toolchain-udeps:
+        description: 'The Rust version to use to run udeps'
+        type: string
+        default: 'stable'
       rust-backtrace:
         description: 'The Rust backtrace settings'
         type: string
@@ -108,6 +112,7 @@ jobs:
       test-suites: ${{ inputs.rust-test-suites }}
       rust-toolchain: ${{ inputs.rust-toolchain }}
       rust-toolchain-formatting: ${{ inputs.rust-toolchain-formatting }}
+      rust-toolchain-udeps: ${{ inputs.rust-toolchain-udeps }}
       rust-backtrace: ${{ inputs.rust-backtrace }}
       install-protoc: ${{ inputs.rust-install-protoc }}
       use-sccache: ${{ inputs.rust-use-sccache }}


### PR DESCRIPTION
Either udeps or my project is [no longer is compiling](https://github.com/WalletConnect/notify-server/actions/runs/7805823226/job/21291184071?pr=351) on nightly. This PR switches to using `nightly-2024-02-04` which worked.

Also exposes the actual toolchain version installed for formatting, as well as exposes the udeps toolchain version for modification.

[Slack conversation](https://walletconnect.slack.com/archives/C068RRL89HC/p1707251841799319)

