### PR TITLE
fix: lint all targets

### DIFF
--- a/.github/workflows/ci-check-app.yml
+++ b/.github/workflows/ci-check-app.yml
@@ -85,7 +85,7 @@ jobs:
         uses: WalletConnect/actions-rs/cargo@2.0.0
         with:
           command: clippy
-          args: --all-features --tests -- -D warnings
+          args: --workspace --all-features --all-targets -- -D warnings
 
   formatting:
     name: Formatting


### PR DESCRIPTION
Same as https://github.com/WalletConnect/WalletConnectRust/pull/63. Linting tests, but not examples. Using `--all-targets` for simplicity. Also adding `--workspace` to lint the entire workspace if we have any.