### PR TITLE
feat(terraform): disabling container insights check in aquasecurity

### DIFF
--- a/.github/workflows/ci-check-infra.yml
+++ b/.github/workflows/ci-check-infra.yml
@@ -107,6 +107,7 @@ jobs:
         with:
           working_directory: ${{ inputs.tf-directory }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          additional_args: '--exclude aws-ecs-enable-container-insight'
 
   tflint:
     name: TFLint


### PR DESCRIPTION
This PR disables the check for the AWS CloudWatch Container Insights in aquasecurity Terraform checker.

The reason to disable the Container Insights is that we are using only CPU and Memory utilization from it and we are moving to use the Prometheus instead. The [full context](https://walletconnect.slack.com/archives/C068RRL89HC/p1704549567804539).

When this check is on, [there is an error in the CI workflow](https://github.com/WalletConnect/blockchain-api/actions/runs/7989709208/job/21816893000?pr=530#step:7:3875).

### Testing

Not tested, but got [an example of how it should look like](https://github.com/ministryofjustice/terraform-github-repository/blob/714060ba594a7c0317a7af2fd1af822182a848a0/.github/workflows/code-scanning.yml#L60).