### PR TITLE
fix: flag to disable udeps

### DIFF
--- a/.github/workflows/ci-check-app.yml
+++ b/.github/workflows/ci-check-app.yml
@@ -23,6 +23,10 @@ on:
         description: 'The Rust version to use to run udeps'
         type: string
         default: 'nightly'
+      check-udeps:
+        description: Enable checking for unusued dependencies
+        type: boolean
+        default: true
       rust-backtrace:
         description: 'The Rust backtrace settings'
         type: string
@@ -186,6 +190,7 @@ jobs:
   unused-dependencies:
     name: Unused Dependencies
     runs-on: ${{ inputs.run-label }}
+    if: ${{ inputs.check-udeps }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,10 @@ on:
         description: 'The Rust version to use to run udeps'
         type: string
         default: 'nightly'
+      check-udeps:
+        description: Enable checking for unusued dependencies
+        type: boolean
+        default: true
       rust-backtrace:
         description: 'The Rust backtrace settings'
         type: string
@@ -113,6 +117,7 @@ jobs:
       rust-toolchain: ${{ inputs.rust-toolchain }}
       rust-toolchain-formatting: ${{ inputs.rust-toolchain-formatting }}
       rust-toolchain-udeps: ${{ inputs.rust-toolchain-udeps }}
+      check-udeps: ${{ inputs.check-udeps }}
       rust-backtrace: ${{ inputs.rust-backtrace }}
       install-protoc: ${{ inputs.rust-install-protoc }}
       use-sccache: ${{ inputs.rust-use-sccache }}


### PR DESCRIPTION
Due to [this bug](https://github.com/est31/cargo-udeps/issues/265) certain repos can't use udeps check until this is resolved. Adds a flag to temporarily disable this check.