### PR TITLE
feat: adding support for checkout private submodules

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -39,6 +39,8 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ inputs.version }}
+          token: ${{ secrets.PRIVATE_SUBMODULE_ACCESS_TOKEN || github.token }}
+          submodules: recursive
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/ci-check-app.yml
+++ b/.github/workflows/ci-check-app.yml
@@ -65,6 +65,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.PRIVATE_SUBMODULE_ACCESS_TOKEN || github.token }}
+          submodules: recursive
 
       - name: Install Rust ${{ inputs.rust-toolchain }}
         uses: WalletConnect/actions-rs/toolchain@2.0.0
@@ -96,7 +99,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
+        with:
+          token: ${{ secrets.PRIVATE_SUBMODULE_ACCESS_TOKEN || github.token }}
+          submodules: recursive
       - name: Install Rust ${{ inputs.rust-toolchain-formatting }}
         uses: WalletConnect/actions-rs/toolchain@2.0.0
         with:
@@ -120,6 +125,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.PRIVATE_SUBMODULE_ACCESS_TOKEN || github.token }}
+          submodules: recursive
 
       - name: Install Rust ${{ inputs.rust-toolchain }}
         uses: WalletConnect/actions-rs/toolchain@2.0.0
@@ -155,6 +163,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.PRIVATE_SUBMODULE_ACCESS_TOKEN || github.token }}
+          submodules: recursive
 
       - name: Parse and export environment variables
         run: |
@@ -194,6 +205,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.PRIVATE_SUBMODULE_ACCESS_TOKEN || github.token }}
+          submodules: recursive
 
       - name: Install Rust ${{ inputs.rust-toolchain-udeps }}
         uses: WalletConnect/actions-rs/toolchain@2.0.0
@@ -217,6 +231,9 @@ jobs:
     runs-on: ${{ inputs.run-label }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.PRIVATE_SUBMODULE_ACCESS_TOKEN || github.token }}
+          submodules: recursive
       - uses: EmbarkStudios/cargo-deny-action@v1
         with:
           command: check license

--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -52,6 +52,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.PRIVATE_SUBMODULE_ACCESS_TOKEN || github.token }}
+          submodules: recursive
 
       - name: Build Task Name
         id: build_task_name

--- a/examples/event_pr.yml
+++ b/examples/event_pr.yml
@@ -41,6 +41,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.PRIVATE_SUBMODULE_ACCESS_TOKEN || github.token }}
+          submodules: recursive
       - uses: WalletConnect/actions/github/paths-filter/@2.4.1
         id: filter
     outputs:

--- a/examples/event_release.yml
+++ b/examples/event_release.yml
@@ -34,6 +34,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.PRIVATE_SUBMODULE_ACCESS_TOKEN || github.token }}
+          submodules: recursive
       - uses: WalletConnect/actions/github/paths-filter/@2.4.1
         id: filter
     outputs:

--- a/examples/sub-validate.yml
+++ b/examples/sub-validate.yml
@@ -36,6 +36,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          token: ${{ secrets.PRIVATE_SUBMODULE_ACCESS_TOKEN || github.token }}
 
       - name: "Install Rust ${{ inputs.version }}"
         uses: WalletConnect/actions-rs/toolchain@2.0.0


### PR DESCRIPTION
# Description

This PR adds support for `checkout` private submodules during the checks and build process by passing `token` argument to the `actions/checkout@v4` GitHub Action.

* The `PRIVATE_SUBMODULE_ACCESS_TOKEN` repository secret is used to provide the token,
* Falling to the default is used in case the secret is empty [according to the action docs](https://github.com/actions/checkout?tab=readme-ov-file#usage). This should cover cases where the secret is not provided due to the absence of private modules.

## How this was tested?

Tested in [#681 PR](https://github.com/WalletConnect/blockchain-api/pull/681) by using the branch of this PR. CI actions successfully passed with the private repo in it.