### PR TITLE
fix: adding secrets inheritance to the build publish workflow

### DIFF
--- a/.github/workflows/release-app.yml
+++ b/.github/workflows/release-app.yml
@@ -67,6 +67,7 @@ jobs:
       fail-fast: false
       matrix:
         env: ${{ fromJson(inputs.publish-envs) }}
+    secrets: inherit
     uses: ./.github/workflows/build-publish.yml
     with:
       version: ${{ needs.update_version.outputs.version }}


### PR DESCRIPTION
This PR adds missed secrets inheritance for the build-publish workflow to [cover the passing of the `PRIVATE_SUBMODULE_ACCESS_TOKEN` secret](https://github.com/WalletConnect/ci_workflows/blob/main/.github/workflows/build-publish.yml#L42C30-L42C60).

This should fix the following release publishing error: https://github.com/WalletConnect/blockchain-api/actions/runs/9669212504/job/26675209849#step:2:270