### PR TITLE
fix: adding secrets inheritance to deploy app

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -88,6 +88,7 @@ jobs:
     name: Deploy App
     needs: [ deploy-infra ]
     if: ${{ (always() && !failure() && !cancelled()) && inputs.deploy-app }}
+    secrets: inherit
     uses: ./.github/workflows/deploy-app.yml
     with:
       version: ${{ inputs.version }}


### PR DESCRIPTION
This PR adds missed secret inheritance to the deploy-app workflow. This should fix the [following deployment error](https://github.com/WalletConnect/blockchain-api/actions/runs/9671311388/job/26682129478#step:2:73).