### PR TITLE
fix: fixing use of `PRIVATE_SUBMODULE_ACCESS_TOKEN` instead of `RELEASE_PAT`

### DIFF
--- a/.github/workflows/ci-check-infra.yml
+++ b/.github/workflows/ci-check-infra.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
-          token: ${{ secrets.RELEASE_PAT }}
+          token: ${{ secrets.PRIVATE_SUBMODULE_ACCESS_TOKEN || github.token }}
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3
@@ -54,7 +54,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
-          token: ${{ secrets.RELEASE_PAT }}
+          token: ${{ secrets.PRIVATE_SUBMODULE_ACCESS_TOKEN || github.token }}
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3
@@ -83,7 +83,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
-          token: ${{ secrets.RELEASE_PAT }}
+          token: ${{ secrets.PRIVATE_SUBMODULE_ACCESS_TOKEN || github.token }}
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3
@@ -114,7 +114,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
-          token: ${{ secrets.RELEASE_PAT }}
+          token: ${{ secrets.PRIVATE_SUBMODULE_ACCESS_TOKEN || github.token }}
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3

--- a/.github/workflows/ci-plan-infra.yml
+++ b/.github/workflows/ci-plan-infra.yml
@@ -65,7 +65,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
-          token: ${{ secrets.RELEASE_PAT }}
+          token: ${{ secrets.PRIVATE_SUBMODULE_ACCESS_TOKEN || github.token }}
 
       - name: Configure AWS Credentials for Monitoring account
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/deploy-infra.yml
+++ b/.github/workflows/deploy-infra.yml
@@ -65,7 +65,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
-          token: ${{ secrets.RELEASE_PAT }}
+          token: ${{ secrets.PRIVATE_SUBMODULE_ACCESS_TOKEN || github.token }}
 
       - name: Configure AWS Credentials for Monitoring account
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/release-app.yml
+++ b/.github/workflows/release-app.yml
@@ -42,7 +42,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
-          token: ${{ secrets.RELEASE_PAT }}
+          token: ${{ secrets.PRIVATE_SUBMODULE_ACCESS_TOKEN || github.token }}
           fetch-depth: 0
 
       - name: Release


### PR DESCRIPTION
This PR extends the use of the `PRIVATE_SUBMODULE_ACCESS_TOKEN` secret or fallback to the github.token for all cases where the repository checkout is used. 
This secret should be used for the repository checkout instead of the `RELEASE_PAT`. This will fix the case when `PRIVATE_SUBMODULE_ACCESS_TOKEN` and `RELEASE_PAT` were created for different orgs.