### PR TITLE
feat: bumping `WalletConnect/actions` version to the latest

### DIFF
--- a/.github/actions/grafana-key/action.yml
+++ b/.github/actions/grafana-key/action.yml
@@ -26,13 +26,13 @@ runs:
   steps:
     - name: Get Grafana details
       id: grafana-get-details
-      uses: WalletConnect/actions/aws/grafana/get-details-by-name/@2.4.1
+      uses: WalletConnect/actions/aws/grafana/get-details-by-name/@2.5.3
       with:
         workspace-name: ${{ inputs.workspace-name }}
 
     - name: Get Grafana key
       id: grafana-get-key
-      uses: WalletConnect/actions/aws/grafana/get-key/@2.4.1
+      uses: WalletConnect/actions/aws/grafana/get-key/@2.5.3
       with:
         key-prefix: ${{ inputs.key-prefix }}
         workspace-id: ${{ steps.grafana-get-details.outputs.workspace-id }}

--- a/.github/workflows/ci-plan-infra.yml
+++ b/.github/workflows/ci-plan-infra.yml
@@ -110,7 +110,7 @@ jobs:
 
       - name: Delete Grafana key
         if: ${{ always() }}
-        uses: WalletConnect/actions/aws/grafana/delete-key/@2.4.1
+        uses: WalletConnect/actions/aws/grafana/delete-key/@2.5.3
         with:
           workspace-id: ${{ steps.grafana-get-key.outputs.workspace-id }}
           key-name: ${{ steps.grafana-get-key.outputs.key-name }}

--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -76,7 +76,7 @@ jobs:
 
       - name: Deploy image to ECS
         id: deploy
-        uses: WalletConnect/actions/aws/ecs/deploy-image/@2.4.1
+        uses: WalletConnect/actions/aws/ecs/deploy-image/@2.5.3
         with:
           aws-role-arn: ${{ inputs.aws-role-arn }}
           aws-region: ${{ inputs.aws-region }}

--- a/.github/workflows/deploy-infra.yml
+++ b/.github/workflows/deploy-infra.yml
@@ -110,7 +110,7 @@ jobs:
 
       - name: Delete Grafana key
         if: ${{ always() }}
-        uses: WalletConnect/actions/aws/grafana/delete-key/@2.4.1
+        uses: WalletConnect/actions/aws/grafana/delete-key/@2.5.3
         with:
           workspace-id: ${{ steps.grafana-get-key.outputs.workspace-id }}
           key-name: ${{ steps.grafana-get-key.outputs.key-name }}

--- a/.github/workflows/release-app.yml
+++ b/.github/workflows/release-app.yml
@@ -44,10 +44,13 @@ jobs:
           submodules: recursive
           token: ${{ secrets.PRIVATE_SUBMODULE_ACCESS_TOKEN || github.token }}
           fetch-depth: 0
+          # Don't persist the credentials because we are using the token to fetch the 
+          # private submodule and then we are using different token to create a release
+          persist-credentials: false
 
       - name: Release
         id: release
-        uses: WalletConnect/actions/github/update-rust-version/@2.4.1
+        uses: WalletConnect/actions/github/update-rust-version/@2.5.3
         with:
           token: ${{ secrets.RELEASE_PAT }}
     outputs:

--- a/.github/workflows/release-get_deployed_version.yml
+++ b/.github/workflows/release-get_deployed_version.yml
@@ -86,7 +86,7 @@ jobs:
     steps:
       - name: Get task definition from ECS
         id: get_task
-        uses: WalletConnect/actions/aws/ecs/get-task-image/@2.4.1
+        uses: WalletConnect/actions/aws/ecs/get-task-image/@2.5.3
         with:
           aws-role-arn: ${{ inputs.aws-role-arn }}
           aws-region: ${{ inputs.aws-region }}

--- a/examples/event_pr.yml
+++ b/examples/event_pr.yml
@@ -44,7 +44,7 @@ jobs:
         with:
           token: ${{ secrets.PRIVATE_SUBMODULE_ACCESS_TOKEN || github.token }}
           submodules: recursive
-      - uses: WalletConnect/actions/github/paths-filter/@2.4.1
+      - uses: WalletConnect/actions/github/paths-filter/@2.5.3
         id: filter
     outputs:
       infra: ${{ steps.filter.outputs.infra }}

--- a/examples/event_release.yml
+++ b/examples/event_release.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           token: ${{ secrets.PRIVATE_SUBMODULE_ACCESS_TOKEN || github.token }}
           submodules: recursive
-      - uses: WalletConnect/actions/github/paths-filter/@2.4.1
+      - uses: WalletConnect/actions/github/paths-filter/@2.5.3
         id: filter
     outputs:
       infra: ${{ steps.filter.outputs.infra }}


### PR DESCRIPTION
## Description

This PR bumped the `WalletConnect/actions` to the [latest 2.5.3 version](https://github.com/WalletConnect/actions/releases/tag/2.5.3) to include the recent changes.

Also, adding `persist-credentials: false` to the checkout action before the release update since we are using two different tokens for fetching and for committing updated releases in autocommit.

## Testing

Tested by invoking the action from the branch.