### PR TITLE
feat: using the current Rust version in the license check

### DIFF
--- a/.github/workflows/ci-check-app.yml
+++ b/.github/workflows/ci-check-app.yml
@@ -236,4 +236,5 @@ jobs:
           submodules: recursive
       - uses: EmbarkStudios/cargo-deny-action@v1
         with:
+          rust-version: ${{ inputs.rust-toolchain }}
           command: check license


### PR DESCRIPTION
This PR forces the license check action to use the toolchain version from the action input instead of the default 1.71.0, causing the following error: `unknown Cargo lock version '4'`.

## How it was tested:

* The action [successfully ran from this branch](https://github.com/reown-com/blockchain-api/actions/runs/12240853605/job/34144658810?pr=860).