### PR TITLE
fix: bumping shared `WalletConnect/actions` workflow version

### DIFF
--- a/.github/actions/grafana-key/action.yml
+++ b/.github/actions/grafana-key/action.yml
@@ -26,13 +26,13 @@ runs:
   steps:
     - name: Get Grafana details
       id: grafana-get-details
-      uses: WalletConnect/actions/aws/grafana/get-details-by-name/@2.5.3
+      uses: WalletConnect/actions/aws/grafana/get-details-by-name/@2.5.4
       with:
         workspace-name: ${{ inputs.workspace-name }}
 
     - name: Get Grafana key
       id: grafana-get-key
-      uses: WalletConnect/actions/aws/grafana/get-key/@2.5.3
+      uses: WalletConnect/actions/aws/grafana/get-key/@2.5.4
       with:
         key-prefix: ${{ inputs.key-prefix }}
         workspace-id: ${{ steps.grafana-get-details.outputs.workspace-id }}

--- a/.github/workflows/ci-plan-infra.yml
+++ b/.github/workflows/ci-plan-infra.yml
@@ -110,7 +110,7 @@ jobs:
 
       - name: Delete Grafana key
         if: ${{ always() }}
-        uses: WalletConnect/actions/aws/grafana/delete-key/@2.5.3
+        uses: WalletConnect/actions/aws/grafana/delete-key/@2.5.4
         with:
           workspace-id: ${{ steps.grafana-get-key.outputs.workspace-id }}
           key-name: ${{ steps.grafana-get-key.outputs.key-name }}

--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -76,7 +76,7 @@ jobs:
 
       - name: Deploy image to ECS
         id: deploy
-        uses: WalletConnect/actions/aws/ecs/deploy-image/@fix/bump_aws_ecs_action_version
+        uses: WalletConnect/actions/aws/ecs/deploy-image/@2.5.4
         with:
           aws-role-arn: ${{ inputs.aws-role-arn }}
           aws-region: ${{ inputs.aws-region }}

--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -76,7 +76,7 @@ jobs:
 
       - name: Deploy image to ECS
         id: deploy
-        uses: WalletConnect/actions/aws/ecs/deploy-image/@2.5.3
+        uses: WalletConnect/actions/aws/ecs/deploy-image/@fix/bump_aws_ecs_action_version
         with:
           aws-role-arn: ${{ inputs.aws-role-arn }}
           aws-region: ${{ inputs.aws-region }}

--- a/.github/workflows/deploy-infra.yml
+++ b/.github/workflows/deploy-infra.yml
@@ -110,7 +110,7 @@ jobs:
 
       - name: Delete Grafana key
         if: ${{ always() }}
-        uses: WalletConnect/actions/aws/grafana/delete-key/@2.5.3
+        uses: WalletConnect/actions/aws/grafana/delete-key/@2.5.4
         with:
           workspace-id: ${{ steps.grafana-get-key.outputs.workspace-id }}
           key-name: ${{ steps.grafana-get-key.outputs.key-name }}

--- a/.github/workflows/release-app.yml
+++ b/.github/workflows/release-app.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Release
         id: release
-        uses: WalletConnect/actions/github/update-rust-version/@2.5.3
+        uses: WalletConnect/actions/github/update-rust-version/@2.5.4
         with:
           token: ${{ secrets.RELEASE_PAT }}
     outputs:

--- a/.github/workflows/release-get_deployed_version.yml
+++ b/.github/workflows/release-get_deployed_version.yml
@@ -86,7 +86,7 @@ jobs:
     steps:
       - name: Get task definition from ECS
         id: get_task
-        uses: WalletConnect/actions/aws/ecs/get-task-image/@2.5.3
+        uses: WalletConnect/actions/aws/ecs/get-task-image/@2.5.4
         with:
           aws-role-arn: ${{ inputs.aws-role-arn }}
           aws-region: ${{ inputs.aws-region }}

--- a/examples/event_pr.yml
+++ b/examples/event_pr.yml
@@ -44,7 +44,7 @@ jobs:
         with:
           token: ${{ secrets.PRIVATE_SUBMODULE_ACCESS_TOKEN || github.token }}
           submodules: recursive
-      - uses: WalletConnect/actions/github/paths-filter/@2.5.3
+      - uses: WalletConnect/actions/github/paths-filter/@2.5.4
         id: filter
     outputs:
       infra: ${{ steps.filter.outputs.infra }}

--- a/examples/event_release.yml
+++ b/examples/event_release.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           token: ${{ secrets.PRIVATE_SUBMODULE_ACCESS_TOKEN || github.token }}
           submodules: recursive
-      - uses: WalletConnect/actions/github/paths-filter/@2.5.3
+      - uses: WalletConnect/actions/github/paths-filter/@2.5.4
         id: filter
     outputs:
       infra: ${{ steps.filter.outputs.infra }}


### PR DESCRIPTION
## Description

This PR bumps the shared `WalletConnect/actions` workflow version to the latest.

## How it was tested

It was tested by running the deploy CD workflow from the branch in the [blockchain-api manual action run](https://github.com/reown-com/blockchain-api/actions/runs/12673381980).

## Merging policy

* [x] Change the branch to the version at `WalletConnect/actions` occurrences.