### PR TITLE
feat: switching to the release only workflow

### DIFF
--- a/.github/workflows/release-app.yml
+++ b/.github/workflows/release-app.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Release
         id: release
-        uses: WalletConnect/actions/github/update-release-version/@feat/implementing_release_only_bump
+        uses: WalletConnect/actions/github/update-release-version/@2.5.5
         with:
           token: ${{ secrets.RELEASE_PAT }}
     outputs:

--- a/.github/workflows/release-app.yml
+++ b/.github/workflows/release-app.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Release
         id: release
-        uses: WalletConnect/actions/github/update-rust-version/@2.5.4
+        uses: WalletConnect/actions/github/update-release-version/@feat/implementing_release_only_bump
         with:
           token: ${{ secrets.RELEASE_PAT }}
     outputs:


### PR DESCRIPTION
# Description

This PR switches to the GitHub release-only workflow instead of the `Cargo.toml` release bump to avoid creating new commits during the release process in the branch-protected repos.

## Merging requirements

* [x] Change the [Walletconnect/actions](https://github.com/WalletConnect/actions/pull/33) branch to the release tag when the dependency merged.