### PR TITLE
feat(caching): updating checkout to v5 and using an `actions/cache` for the cargo clippy and build

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ${{ inputs.run-label }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           ref: ${{ inputs.version }}

--- a/.github/workflows/ci-check-app.yml
+++ b/.github/workflows/ci-check-app.yml
@@ -84,8 +84,7 @@ jobs:
             ~/.cargo/bin/
             ~/.cargo/registry/
             ~/.cargo/git/
-            target/debug/deps/
-            target/debug/.fingerprint/
+            target/
           key: ${{ runner.os }}-cargo-clippy-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Install Protoc
@@ -127,8 +126,7 @@ jobs:
             ~/.cargo/bin/
             ~/.cargo/registry/
             ~/.cargo/git/
-            target/debug/deps/
-            target/debug/.fingerprint/
+            target/
           key: ${{ runner.os }}-cargo-formatting-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Run sccache-cache
@@ -165,8 +163,7 @@ jobs:
             ~/.cargo/bin/
             ~/.cargo/registry/
             ~/.cargo/git/
-            target/debug/deps/
-            target/debug/.fingerprint/
+            target/
           key: ${{ runner.os }}-cargo-tests-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Install Protoc
@@ -222,8 +219,7 @@ jobs:
             ~/.cargo/bin/
             ~/.cargo/registry/
             ~/.cargo/git/
-            target/debug/deps/
-            target/debug/.fingerprint/
+            target/
           key: ${{ runner.os }}-cargo-tests-suites-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Install Protoc
@@ -267,8 +263,7 @@ jobs:
             ~/.cargo/bin/
             ~/.cargo/registry/
             ~/.cargo/git/
-            target/debug/deps/
-            target/debug/.fingerprint/
+            target/
           key: ${{ runner.os }}-cargo-unused-deps-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Run sccache-cache

--- a/.github/workflows/ci-check-app.yml
+++ b/.github/workflows/ci-check-app.yml
@@ -77,12 +77,17 @@ jobs:
           components: 'cargo,clippy'
           override: true
 
-      - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@v2
+      - name: Cache Cargo registry
+        uses: actions/cache@v4
         with:
-          cache-on-failure: true
-          cache-all-crates: true
-          cache-workspace-crates: true
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
 
       - name: Install Protoc
         if: ${{ inputs.install-protoc == true }}
@@ -116,12 +121,17 @@ jobs:
           profile: 'default'
           override: true
 
-      - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@v2
+      - name: Cache Cargo registry
+        uses: actions/cache@v4
         with:
-          cache-on-failure: true
-          cache-all-crates: true
-          cache-workspace-crates: true
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
 
       - name: Run sccache-cache
         if: ${{ inputs.use-sccache == true }}
@@ -150,12 +160,17 @@ jobs:
           profile: 'default'
           override: true
 
-      - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@v2
+      - name: Cache Cargo registry
+        uses: actions/cache@v4
         with:
-          cache-on-failure: true
-          cache-all-crates: true
-          cache-workspace-crates: true
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
 
       - name: Install Protoc
         if: ${{ inputs.install-protoc == true }}
@@ -203,12 +218,17 @@ jobs:
           profile: 'default'
           override: true
 
-      - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@v2
+      - name: Cache Cargo registry
+        uses: actions/cache@v4
         with:
-          cache-on-failure: true
-          cache-all-crates: true
-          cache-workspace-crates: true
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
 
       - name: Install Protoc
         if: ${{ inputs.install-protoc == true }}
@@ -244,12 +264,17 @@ jobs:
           profile: 'default'
           override: true
 
-      - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@v2
+      - name: Cache Cargo registry
+        uses: actions/cache@v4
         with:
-          cache-on-failure: true
-          cache-all-crates: true
-          cache-workspace-crates: true
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
 
       - name: Run sccache-cache
         if: ${{ inputs.use-sccache == true }}

--- a/.github/workflows/ci-check-app.yml
+++ b/.github/workflows/ci-check-app.yml
@@ -79,6 +79,10 @@ jobs:
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+          cache-all-crates: true
+          cache-workspace-crates: true
 
       - name: Install Protoc
         if: ${{ inputs.install-protoc == true }}
@@ -114,6 +118,10 @@ jobs:
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+          cache-all-crates: true
+          cache-workspace-crates: true
 
       - name: Run sccache-cache
         if: ${{ inputs.use-sccache == true }}
@@ -144,6 +152,10 @@ jobs:
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+          cache-all-crates: true
+          cache-workspace-crates: true
 
       - name: Install Protoc
         if: ${{ inputs.install-protoc == true }}
@@ -193,6 +205,10 @@ jobs:
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+          cache-all-crates: true
+          cache-workspace-crates: true
 
       - name: Install Protoc
         if: ${{ inputs.install-protoc == true }}
@@ -230,6 +246,10 @@ jobs:
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+          cache-all-crates: true
+          cache-workspace-crates: true
 
       - name: Run sccache-cache
         if: ${{ inputs.use-sccache == true }}

--- a/.github/workflows/ci-check-app.yml
+++ b/.github/workflows/ci-check-app.yml
@@ -82,9 +82,10 @@ jobs:
         with:
           path: |
             ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
+            ~/.cargo/registry/
+            ~/.cargo/git/
+            target/debug/deps/
+            target/debug/.fingerprint/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-cargo-
@@ -126,9 +127,10 @@ jobs:
         with:
           path: |
             ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
+            ~/.cargo/registry/
+            ~/.cargo/git/
+            target/debug/deps/
+            target/debug/.fingerprint/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-cargo-
@@ -165,9 +167,10 @@ jobs:
         with:
           path: |
             ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
+            ~/.cargo/registry/
+            ~/.cargo/git/
+            target/debug/deps/
+            target/debug/.fingerprint/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-cargo-
@@ -223,9 +226,10 @@ jobs:
         with:
           path: |
             ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
+            ~/.cargo/registry/
+            ~/.cargo/git/
+            target/debug/deps/
+            target/debug/.fingerprint/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-cargo-
@@ -269,9 +273,10 @@ jobs:
         with:
           path: |
             ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
+            ~/.cargo/registry/
+            ~/.cargo/git/
+            target/debug/deps/
+            target/debug/.fingerprint/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-cargo-

--- a/.github/workflows/ci-check-app.yml
+++ b/.github/workflows/ci-check-app.yml
@@ -86,7 +86,7 @@ jobs:
             ~/.cargo/git/
             target/debug/deps/
             target/debug/.fingerprint/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-clippy-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-cargo-
 
@@ -131,7 +131,7 @@ jobs:
             ~/.cargo/git/
             target/debug/deps/
             target/debug/.fingerprint/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-formatting-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-cargo-
 
@@ -171,7 +171,7 @@ jobs:
             ~/.cargo/git/
             target/debug/deps/
             target/debug/.fingerprint/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-tests-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-cargo-
 
@@ -230,7 +230,7 @@ jobs:
             ~/.cargo/git/
             target/debug/deps/
             target/debug/.fingerprint/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-tests-suites-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-cargo-
 
@@ -277,7 +277,7 @@ jobs:
             ~/.cargo/git/
             target/debug/deps/
             target/debug/.fingerprint/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-unused-deps-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-cargo-
 

--- a/.github/workflows/ci-check-app.yml
+++ b/.github/workflows/ci-check-app.yml
@@ -64,7 +64,7 @@ jobs:
     runs-on: ${{ inputs.run-label }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           token: ${{ secrets.PRIVATE_SUBMODULE_ACCESS_TOKEN || github.token }}
           submodules: recursive
@@ -98,7 +98,7 @@ jobs:
     runs-on: ${{ inputs.run-label }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           token: ${{ secrets.PRIVATE_SUBMODULE_ACCESS_TOKEN || github.token }}
           submodules: recursive
@@ -124,7 +124,7 @@ jobs:
     runs-on: ${{ inputs.run-label }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           token: ${{ secrets.PRIVATE_SUBMODULE_ACCESS_TOKEN || github.token }}
           submodules: recursive
@@ -162,7 +162,7 @@ jobs:
     runs-on: ${{ inputs.run-label }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           token: ${{ secrets.PRIVATE_SUBMODULE_ACCESS_TOKEN || github.token }}
           submodules: recursive
@@ -204,7 +204,7 @@ jobs:
     if: ${{ inputs.check-udeps }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           token: ${{ secrets.PRIVATE_SUBMODULE_ACCESS_TOKEN || github.token }}
           submodules: recursive
@@ -230,7 +230,7 @@ jobs:
     name: Licenses
     runs-on: ${{ inputs.run-label }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           token: ${{ secrets.PRIVATE_SUBMODULE_ACCESS_TOKEN || github.token }}
           submodules: recursive

--- a/.github/workflows/ci-check-app.yml
+++ b/.github/workflows/ci-check-app.yml
@@ -77,6 +77,9 @@ jobs:
           components: 'cargo,clippy'
           override: true
 
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+
       - name: Install Protoc
         if: ${{ inputs.install-protoc == true }}
         uses: arduino/setup-protoc@v3
@@ -109,6 +112,9 @@ jobs:
           profile: 'default'
           override: true
 
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+
       - name: Run sccache-cache
         if: ${{ inputs.use-sccache == true }}
         uses: mozilla-actions/sccache-action@v0.0.4
@@ -135,6 +141,9 @@ jobs:
           toolchain: ${{ inputs.rust-toolchain }}
           profile: 'default'
           override: true
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
 
       - name: Install Protoc
         if: ${{ inputs.install-protoc == true }}
@@ -182,6 +191,9 @@ jobs:
           profile: 'default'
           override: true
 
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+
       - name: Install Protoc
         if: ${{ inputs.install-protoc == true }}
         uses: arduino/setup-protoc@v3
@@ -215,6 +227,9 @@ jobs:
           toolchain: ${{ inputs.rust-toolchain-udeps }}
           profile: 'default'
           override: true
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
 
       - name: Run sccache-cache
         if: ${{ inputs.use-sccache == true }}

--- a/.github/workflows/ci-check-app.yml
+++ b/.github/workflows/ci-check-app.yml
@@ -87,8 +87,6 @@ jobs:
             target/debug/deps/
             target/debug/.fingerprint/
           key: ${{ runner.os }}-cargo-clippy-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-
 
       - name: Install Protoc
         if: ${{ inputs.install-protoc == true }}
@@ -132,8 +130,6 @@ jobs:
             target/debug/deps/
             target/debug/.fingerprint/
           key: ${{ runner.os }}-cargo-formatting-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-
 
       - name: Run sccache-cache
         if: ${{ inputs.use-sccache == true }}
@@ -172,8 +168,6 @@ jobs:
             target/debug/deps/
             target/debug/.fingerprint/
           key: ${{ runner.os }}-cargo-tests-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-
 
       - name: Install Protoc
         if: ${{ inputs.install-protoc == true }}
@@ -231,8 +225,6 @@ jobs:
             target/debug/deps/
             target/debug/.fingerprint/
           key: ${{ runner.os }}-cargo-tests-suites-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-
 
       - name: Install Protoc
         if: ${{ inputs.install-protoc == true }}
@@ -278,8 +270,6 @@ jobs:
             target/debug/deps/
             target/debug/.fingerprint/
           key: ${{ runner.os }}-cargo-unused-deps-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-
 
       - name: Run sccache-cache
         if: ${{ inputs.use-sccache == true }}

--- a/.github/workflows/ci-check-infra.yml
+++ b/.github/workflows/ci-check-infra.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ${{ inputs.run-label }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
           token: ${{ secrets.PRIVATE_SUBMODULE_ACCESS_TOKEN || github.token }}
@@ -51,7 +51,7 @@ jobs:
     runs-on: ${{ inputs.run-label }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
           token: ${{ secrets.PRIVATE_SUBMODULE_ACCESS_TOKEN || github.token }}
@@ -80,7 +80,7 @@ jobs:
     runs-on: ${{ inputs.run-label }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
           token: ${{ secrets.PRIVATE_SUBMODULE_ACCESS_TOKEN || github.token }}
@@ -111,7 +111,7 @@ jobs:
     runs-on: ${{ inputs.run-label }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
           token: ${{ secrets.PRIVATE_SUBMODULE_ACCESS_TOKEN || github.token }}

--- a/.github/workflows/ci-plan-infra.yml
+++ b/.github/workflows/ci-plan-infra.yml
@@ -62,7 +62,7 @@ jobs:
       url: ${{ inputs.stage-url }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
           token: ${{ secrets.PRIVATE_SUBMODULE_ACCESS_TOKEN || github.token }}

--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -51,7 +51,7 @@ jobs:
       url: ${{ inputs.stage-url }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           token: ${{ secrets.PRIVATE_SUBMODULE_ACCESS_TOKEN || github.token }}
           submodules: recursive

--- a/.github/workflows/deploy-infra.yml
+++ b/.github/workflows/deploy-infra.yml
@@ -62,7 +62,7 @@ jobs:
       url: ${{ inputs.stage-url }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
           token: ${{ secrets.PRIVATE_SUBMODULE_ACCESS_TOKEN || github.token }}

--- a/.github/workflows/release-app.yml
+++ b/.github/workflows/release-app.yml
@@ -39,7 +39,7 @@ jobs:
     runs-on: ${{ inputs.run-label }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
           token: ${{ secrets.PRIVATE_SUBMODULE_ACCESS_TOKEN || github.token }}

--- a/examples/event_pr.yml
+++ b/examples/event_pr.yml
@@ -40,7 +40,7 @@ jobs:
     name: Paths Filter
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           token: ${{ secrets.PRIVATE_SUBMODULE_ACCESS_TOKEN || github.token }}
           submodules: recursive

--- a/examples/event_release.yml
+++ b/examples/event_release.yml
@@ -33,7 +33,7 @@ jobs:
     name: Paths Filter
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           token: ${{ secrets.PRIVATE_SUBMODULE_ACCESS_TOKEN || github.token }}
           submodules: recursive

--- a/examples/sub-validate.yml
+++ b/examples/sub-validate.yml
@@ -35,7 +35,7 @@ jobs:
       url: ${{ inputs.stage-url }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
           token: ${{ secrets.PRIVATE_SUBMODULE_ACCESS_TOKEN || github.token }}


### PR DESCRIPTION
# Updating checkout to v5 and using an actions/cache for the cargo build

This PR updates `actions/checkout` workflow to version 5 and implement cargo clippy and build caching using the `actions/cache` by caching cargo directories and using `Cargo.lock` hash to invalidate the caching.
These directories will be cached:

* ~/.cargo/bin/
* ~/.cargo/registry/
* ~/.cargo/git/
* target/
