### PR TITLE
feat: restore and save cache as options, updating the checkout version

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ${{ inputs.run-label }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: ${{ inputs.version }}

--- a/.github/workflows/ci-check-app.yml
+++ b/.github/workflows/ci-check-app.yml
@@ -72,7 +72,7 @@ jobs:
     runs-on: ${{ inputs.run-label }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           token: ${{ secrets.PRIVATE_SUBMODULE_ACCESS_TOKEN || github.token }}
           submodules: recursive
@@ -129,7 +129,7 @@ jobs:
     runs-on: ${{ inputs.run-label }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           token: ${{ secrets.PRIVATE_SUBMODULE_ACCESS_TOKEN || github.token }}
           submodules: recursive
@@ -178,7 +178,7 @@ jobs:
     runs-on: ${{ inputs.run-label }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           token: ${{ secrets.PRIVATE_SUBMODULE_ACCESS_TOKEN || github.token }}
           submodules: recursive
@@ -239,7 +239,7 @@ jobs:
     runs-on: ${{ inputs.run-label }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           token: ${{ secrets.PRIVATE_SUBMODULE_ACCESS_TOKEN || github.token }}
           submodules: recursive
@@ -304,7 +304,7 @@ jobs:
     if: ${{ inputs.check-udeps }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           token: ${{ secrets.PRIVATE_SUBMODULE_ACCESS_TOKEN || github.token }}
           submodules: recursive
@@ -353,7 +353,7 @@ jobs:
     name: Licenses
     runs-on: ${{ inputs.run-label }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           token: ${{ secrets.PRIVATE_SUBMODULE_ACCESS_TOKEN || github.token }}
           submodules: recursive

--- a/.github/workflows/ci-check-app.yml
+++ b/.github/workflows/ci-check-app.yml
@@ -51,6 +51,14 @@ on:
         description: 'The run label to use for the actions'
         type: string
         default: 'ubuntu-latest'
+      rust-cache-prefix:
+        description: 'Prefix for Rust cache key (bump to invalidate all caches)'
+        type: string
+        default: 'v0-rust'
+      rust-cache-save:
+        description: 'Whether to save the Rust cache (set to false for PRs to only restore from main)'
+        type: boolean
+        default: true
 
 env:
   RUST_BACKTRACE: ${{ inputs.rust-backtrace }}
@@ -77,15 +85,17 @@ jobs:
           components: 'cargo,clippy'
           override: true
 
-      - name: Cache Cargo registry
-        uses: actions/cache@v4
+      - name: Restore Cargo cache
+        uses: actions/cache/restore@v4
         with:
           path: |
             ~/.cargo/bin/
             ~/.cargo/registry/
             ~/.cargo/git/
             target/
-          key: ${{ runner.os }}-cargo-clippy-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ inputs.rust-cache-prefix }}-${{ runner.os }}-cargo-clippy-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ inputs.rust-cache-prefix }}-${{ runner.os }}-cargo-clippy-
 
       - name: Install Protoc
         if: ${{ inputs.install-protoc == true }}
@@ -103,6 +113,17 @@ jobs:
           command: clippy
           args: --workspace --all-features --all-targets -- -D warnings
 
+      - name: Save Cargo cache
+        if: ${{ inputs.rust-cache-save }}
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/
+            ~/.cargo/git/
+            target/
+          key: ${{ inputs.rust-cache-prefix }}-${{ runner.os }}-cargo-clippy-${{ hashFiles('**/Cargo.lock') }}
+
   formatting:
     name: Formatting
     runs-on: ${{ inputs.run-label }}
@@ -119,15 +140,17 @@ jobs:
           profile: 'default'
           override: true
 
-      - name: Cache Cargo registry
-        uses: actions/cache@v4
+      - name: Restore Cargo cache
+        uses: actions/cache/restore@v4
         with:
           path: |
             ~/.cargo/bin/
             ~/.cargo/registry/
             ~/.cargo/git/
             target/
-          key: ${{ runner.os }}-cargo-formatting-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ inputs.rust-cache-prefix }}-${{ runner.os }}-cargo-formatting-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ inputs.rust-cache-prefix }}-${{ runner.os }}-cargo-formatting-
 
       - name: Run sccache-cache
         if: ${{ inputs.use-sccache == true }}
@@ -138,6 +161,17 @@ jobs:
         with:
           command: fmt
           args: -- --check
+
+      - name: Save Cargo cache
+        if: ${{ inputs.rust-cache-save }}
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/
+            ~/.cargo/git/
+            target/
+          key: ${{ inputs.rust-cache-prefix }}-${{ runner.os }}-cargo-formatting-${{ hashFiles('**/Cargo.lock') }}
 
   tests:
     name: Unit Tests
@@ -156,15 +190,17 @@ jobs:
           profile: 'default'
           override: true
 
-      - name: Cache Cargo registry
-        uses: actions/cache@v4
+      - name: Restore Cargo cache
+        uses: actions/cache/restore@v4
         with:
           path: |
             ~/.cargo/bin/
             ~/.cargo/registry/
             ~/.cargo/git/
             target/
-          key: ${{ runner.os }}-cargo-tests-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ inputs.rust-cache-prefix }}-${{ runner.os }}-cargo-tests-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ inputs.rust-cache-prefix }}-${{ runner.os }}-cargo-tests-
 
       - name: Install Protoc
         if: ${{ inputs.install-protoc == true }}
@@ -181,6 +217,17 @@ jobs:
         with:
           command: test
           args: ${{ inputs.test-args }}
+
+      - name: Save Cargo cache
+        if: ${{ inputs.rust-cache-save }}
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/
+            ~/.cargo/git/
+            target/
+          key: ${{ inputs.rust-cache-prefix }}-${{ runner.os }}-cargo-tests-${{ hashFiles('**/Cargo.lock') }}
 
   tests-suites:
     name: Tests Suite "${{ matrix.element }}"
@@ -212,15 +259,17 @@ jobs:
           profile: 'default'
           override: true
 
-      - name: Cache Cargo registry
-        uses: actions/cache@v4
+      - name: Restore Cargo cache
+        uses: actions/cache/restore@v4
         with:
           path: |
             ~/.cargo/bin/
             ~/.cargo/registry/
             ~/.cargo/git/
             target/
-          key: ${{ runner.os }}-cargo-tests-suites-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ inputs.rust-cache-prefix }}-${{ runner.os }}-cargo-tests-suites-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ inputs.rust-cache-prefix }}-${{ runner.os }}-cargo-tests-suites-
 
       - name: Install Protoc
         if: ${{ inputs.install-protoc == true }}
@@ -237,6 +286,17 @@ jobs:
         with:
           command: test
           args: --test ${{ matrix.element }}
+
+      - name: Save Cargo cache
+        if: ${{ inputs.rust-cache-save }}
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/
+            ~/.cargo/git/
+            target/
+          key: ${{ inputs.rust-cache-prefix }}-${{ runner.os }}-cargo-tests-suites-${{ hashFiles('**/Cargo.lock') }}
 
   unused-dependencies:
     name: Unused Dependencies
@@ -256,15 +316,17 @@ jobs:
           profile: 'default'
           override: true
 
-      - name: Cache Cargo registry
-        uses: actions/cache@v4
+      - name: Restore Cargo cache
+        uses: actions/cache/restore@v4
         with:
           path: |
             ~/.cargo/bin/
             ~/.cargo/registry/
             ~/.cargo/git/
             target/
-          key: ${{ runner.os }}-cargo-unused-deps-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ inputs.rust-cache-prefix }}-${{ runner.os }}-cargo-unused-deps-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ inputs.rust-cache-prefix }}-${{ runner.os }}-cargo-unused-deps-
 
       - name: Run sccache-cache
         if: ${{ inputs.use-sccache == true }}
@@ -275,6 +337,17 @@ jobs:
         with:
           version: 'v0.1.43'
           args: '--all-targets'
+
+      - name: Save Cargo cache
+        if: ${{ inputs.rust-cache-save }}
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/
+            ~/.cargo/git/
+            target/
+          key: ${{ inputs.rust-cache-prefix }}-${{ runner.os }}-cargo-unused-deps-${{ hashFiles('**/Cargo.lock') }}
 
   license:
     name: Licenses

--- a/.github/workflows/ci-check-infra.yml
+++ b/.github/workflows/ci-check-infra.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ${{ inputs.run-label }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           submodules: recursive
           token: ${{ secrets.PRIVATE_SUBMODULE_ACCESS_TOKEN || github.token }}
@@ -51,7 +51,7 @@ jobs:
     runs-on: ${{ inputs.run-label }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           submodules: recursive
           token: ${{ secrets.PRIVATE_SUBMODULE_ACCESS_TOKEN || github.token }}
@@ -80,7 +80,7 @@ jobs:
     runs-on: ${{ inputs.run-label }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           submodules: recursive
           token: ${{ secrets.PRIVATE_SUBMODULE_ACCESS_TOKEN || github.token }}
@@ -111,7 +111,7 @@ jobs:
     runs-on: ${{ inputs.run-label }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           submodules: recursive
           token: ${{ secrets.PRIVATE_SUBMODULE_ACCESS_TOKEN || github.token }}

--- a/.github/workflows/ci-plan-infra.yml
+++ b/.github/workflows/ci-plan-infra.yml
@@ -62,7 +62,7 @@ jobs:
       url: ${{ inputs.stage-url }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           submodules: recursive
           token: ${{ secrets.PRIVATE_SUBMODULE_ACCESS_TOKEN || github.token }}

--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -51,7 +51,7 @@ jobs:
       url: ${{ inputs.stage-url }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           token: ${{ secrets.PRIVATE_SUBMODULE_ACCESS_TOKEN || github.token }}
           submodules: recursive

--- a/.github/workflows/deploy-infra.yml
+++ b/.github/workflows/deploy-infra.yml
@@ -62,7 +62,7 @@ jobs:
       url: ${{ inputs.stage-url }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           submodules: recursive
           token: ${{ secrets.PRIVATE_SUBMODULE_ACCESS_TOKEN || github.token }}

--- a/.github/workflows/release-app.yml
+++ b/.github/workflows/release-app.yml
@@ -39,7 +39,7 @@ jobs:
     runs-on: ${{ inputs.run-label }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           submodules: recursive
           token: ${{ secrets.PRIVATE_SUBMODULE_ACCESS_TOKEN || github.token }}

--- a/examples/event_pr.yml
+++ b/examples/event_pr.yml
@@ -40,7 +40,7 @@ jobs:
     name: Paths Filter
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           token: ${{ secrets.PRIVATE_SUBMODULE_ACCESS_TOKEN || github.token }}
           submodules: recursive

--- a/examples/event_release.yml
+++ b/examples/event_release.yml
@@ -33,7 +33,7 @@ jobs:
     name: Paths Filter
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           token: ${{ secrets.PRIVATE_SUBMODULE_ACCESS_TOKEN || github.token }}
           submodules: recursive

--- a/examples/sub-validate.yml
+++ b/examples/sub-validate.yml
@@ -35,7 +35,7 @@ jobs:
       url: ${{ inputs.stage-url }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           submodules: recursive
           token: ${{ secrets.PRIVATE_SUBMODULE_ACCESS_TOKEN || github.token }}
@@ -47,6 +47,18 @@ jobs:
           profile: 'default'
           override: true
 
+      - name: Restore Cargo cache
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/
+            ~/.cargo/git/
+            target/
+          key: v0-rust-${{ runner.os }}-cargo-integration-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            v0-rust-${{ runner.os }}-cargo-integration-
+
       - name: "Run Integration Tests"
         uses: WalletConnect/actions-rs/cargo@2.0.0
         env:
@@ -55,3 +67,13 @@ jobs:
         with:
           command: test
           args: --test integration
+
+      - name: Save Cargo cache
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/
+            ~/.cargo/git/
+            target/
+          key: v0-rust-${{ runner.os }}-cargo-integration-${{ hashFiles('**/Cargo.lock') }}


### PR DESCRIPTION
# Description

This PR distinguish cargo cache saving and restoring to allow saving the cache to the main branch and restore-only on PRs `ci-check-app.yml` run to avoid polluting the GHA cache and only reuse the cache from the main branch instead of creating cache for each branch.
This will also allow to reuse the cache on the deployment stage.

This PR updates `actions/checkout` to version 6.

Also, cargo caching for the cargo integration tests in `sub-validate.yml` was added.