### PR TITLE
fix: forward rust-cache-prefix and rust-cache-save inputs to ci-check-app

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,14 @@ on:
         description: 'The run label to use for the actions'
         type: string
         default: 'ubuntu-latest'
+      rust-cache-prefix:
+        description: 'Prefix for Rust cache key (bump to invalidate all caches)'
+        type: string
+        default: 'v0-rust'
+      rust-cache-save:
+        description: 'Whether to save the Rust cache (set to false for PRs to only restore from main)'
+        type: boolean
+        default: true
     secrets:
       TF_API_TOKEN:
         required: true
@@ -124,6 +132,8 @@ jobs:
       use-postgresql: ${{ inputs.rust-use-postgresql }}
       test-env-vars: ${{ inputs.rust-test-env-vars }}
       run-label: ${{ inputs.run-label }}
+      rust-cache-prefix: ${{ inputs.rust-cache-prefix }}
+      rust-cache-save: ${{ inputs.rust-cache-save }}
 
   check-infra:
     name: Check Infra


### PR DESCRIPTION
# Description

The ci-check-app.yml workflow has rust-cache-prefix and rust-cache-save
inputs, but ci.yml was not exposing or forwarding them. 
This caused workflows that tried to pass rust-cache-save: false to fail with
'Input is not defined in the called workflow' error.
This PR fixes this issue with a properly passing the variables.