### PR TITLE
feat: add Claude AI review for terraform plans

### DIFF
--- a/.github/workflows/ci-plan-infra.yml
+++ b/.github/workflows/ci-plan-infra.yml
@@ -42,10 +42,13 @@ on:
     secrets:
       TF_API_TOKEN:
         required: true
+      ANTHROPIC_API_KEY:
+        required: false
 
 permissions:
   contents: read
   id-token: write
+  pull-requests: write
 
 concurrency: deploy-${{ inputs.stage }}
 
@@ -106,7 +109,25 @@ jobs:
 
       - name: Plan ${{ inputs.stage }}
         working-directory: ${{ inputs.tf-directory }}
-        run: terraform plan -no-color
+        run: |
+          set -o pipefail
+          terraform plan -no-color 2>&1 | tee /tmp/plan_output.txt
+
+      - name: Upload Plan Output
+        if: always() && github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v4
+        with:
+          name: terraform-plan-${{ inputs.stage }}
+          path: /tmp/plan_output.txt
+          retention-days: 1
+
+      - name: Claude AI Review
+        if: github.event_name == 'pull_request' && secrets.ANTHROPIC_API_KEY != ''
+        continue-on-error: true
+        uses: WalletConnect/actions/claude/terraform-plan-review@master
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          terraform_plan_file: /tmp/plan_output.txt
 
       - name: Delete Grafana key
         if: ${{ always() }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,10 +108,14 @@ on:
     secrets:
       TF_API_TOKEN:
         required: true
+      ANTHROPIC_API_KEY:
+        required: false
+        description: 'Anthropic API key for Claude AI terraform plan review'
 
 permissions:
   contents: read
   id-token: write
+  pull-requests: write
 
 jobs:
   check-app:


### PR DESCRIPTION
## Summary
- Add optional `ANTHROPIC_API_KEY` secret to enable Claude AI review of terraform plans
- Save terraform plan output to file and upload as artifact
- Add Claude AI review step that runs when `ANTHROPIC_API_KEY` is provided
- Add `pull-requests: write` permission for PR comments

## How it works
When a repo using `ci_workflows` provides the `ANTHROPIC_API_KEY` secret:
1. Terraform plan output is saved to a file
2. Plan output is uploaded as an artifact (`terraform-plan-{stage}`)
3. Claude AI reviews the plan and posts findings as PR comments

Repos without `ANTHROPIC_API_KEY` continue to work as before - the AI review step is skipped.

## Test plan
- [ ] Create a test PR in pay-core with terraform changes
- [ ] Verify AI review runs and posts comment
- [ ] Verify behavior when `ANTHROPIC_API_KEY` is not set (should skip gracefully)

🤖 Generated with [Claude Code](https://claude.com/claude-code)