### PR TITLE
fix: fixing anthropic secret in a condition

### DIFF
--- a/.github/workflows/ci-plan-infra.yml
+++ b/.github/workflows/ci-plan-infra.yml
@@ -122,7 +122,7 @@ jobs:
           retention-days: 1
 
       - name: Claude AI Review
-        if: github.event_name == 'pull_request' && secrets.ANTHROPIC_API_KEY != ''
+        if: github.event_name == 'pull_request'
         continue-on-error: true
         uses: WalletConnect/actions/claude/terraform-plan-review@master
         with:


### PR DESCRIPTION
# Description

This PR fixes the syntax error:

```
[Invalid workflow file: .github/workflows/event_release.yml#L46](https://github.com/WalletConnect/pay-core/actions/runs/21297047359/workflow)
error parsing called workflow
".github/workflows/event_release.yml"
-> "WalletConnect/ci_workflows/.github/workflows/ci.yml@0.2.23" (source tag with sha:10fbfcefcee93f1a28a1666835494c903386389d)
--> "./.github/workflows/ci-plan-infra.yml" (source tag with sha:10fbfcefcee93f1a28a1666835494c903386389d)
: (Line: 125, Col: 13): Unrecognized named-value: 'secrets'. Located at position 40 within expression: github.event_name == 'pull_request' && secrets.ANTHROPIC_API_KEY != ''
```

Fixing by removing the `secrets` from the condition and using the `continue-on-error: true` which is already handles the failure gracefully.