### PR TITLE
fix: swapping TFSec to Trivy

### DIFF
--- a/.github/workflows/ci-check-infra.yml
+++ b/.github/workflows/ci-check-infra.yml
@@ -75,8 +75,8 @@ jobs:
         working-directory: ${{ inputs.tf-directory }}
         run: terraform validate
 
-  tfsec:
-    name: TFSec
+  trivy:
+    name: Trivy
     runs-on: ${{ inputs.run-label }}
     steps:
       - name: Checkout
@@ -100,11 +100,14 @@ jobs:
         working-directory: ${{ inputs.tf-directory }}
         run: terraform init -no-color
 
-      - uses: aquasecurity/tfsec-action@v1.0.3
+      - name: Run Trivy IaC scanner
+        uses: aquasecurity/trivy-action@0.28.0
         with:
-          working_directory: ${{ inputs.tf-directory }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          additional_args: '--exclude aws-ecs-enable-container-insight'
+          scan-type: 'config'
+          scan-ref: ${{ inputs.tf-directory }}
+          exit-code: '1'
+          skip-dirs: '.terraform'
+          skip-checks: 'AVD-AWS-0034'
 
   tflint:
     name: TFLint

--- a/.github/workflows/ci-check-infra.yml
+++ b/.github/workflows/ci-check-infra.yml
@@ -102,12 +102,14 @@ jobs:
 
       - name: Run Trivy IaC scanner
         uses: aquasecurity/trivy-action@v0.35.0
+        env:
+          TRIVY_SKIP_CHECKS: AVD-AWS-0034
         with:
           scan-type: 'config'
           scan-ref: ${{ inputs.tf-directory }}
-          exit-code: '0'
+          exit-code: '1'
+          severity: 'HIGH,CRITICAL'
           skip-dirs: '.terraform'
-          skip-checks: 'AVD-AWS-0034'
 
   tflint:
     name: TFLint

--- a/.github/workflows/ci-check-infra.yml
+++ b/.github/workflows/ci-check-infra.yml
@@ -101,11 +101,11 @@ jobs:
         run: terraform init -no-color
 
       - name: Run Trivy IaC scanner
-        uses: aquasecurity/trivy-action@v0.35.0
+        uses: aquasecurity/trivy-action@0.28.0
         with:
           scan-type: 'config'
           scan-ref: ${{ inputs.tf-directory }}
-          exit-code: '1'
+          exit-code: '0'
           skip-dirs: '.terraform'
           skip-checks: 'AVD-AWS-0034'
 

--- a/.github/workflows/ci-check-infra.yml
+++ b/.github/workflows/ci-check-infra.yml
@@ -101,7 +101,7 @@ jobs:
         run: terraform init -no-color
 
       - name: Run Trivy IaC scanner
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@v0.35.0
         with:
           scan-type: 'config'
           scan-ref: ${{ inputs.tf-directory }}


### PR DESCRIPTION
This PR swaps TFSec to Trivy, successor of the TFSec, because of the TFSec deprecation.
The Trivy scan set to fail only on high and critical issues.
Skip check of `AVD-AWS-0034` was added to not check the container insights.